### PR TITLE
[api] Switched Ledger to use an Interface

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -32,7 +32,7 @@ import (
 )
 
 type API struct {
-	Repo    repo.Ledger
+	Repo    repo.LedgerInterface
 	Tracker tracker.Tracker
 
 	listen_address string
@@ -47,7 +47,7 @@ func doResult(c *gin.Context, value interface{}, err error) {
 	}
 }
 
-func NewAPI(listen string, rep repo.Ledger, track tracker.Tracker) API {
+func NewAPI(listen string, rep repo.LedgerInterface, track tracker.Tracker) API {
 	a := API{Repo: rep, Tracker: track}
 	a.listen_address = listen
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -38,13 +38,27 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
+type LedgerInterface interface {
+	Sync() error
+	GetMessage(peer_name string, sequence string) (string, error)
+	GetLastSeq(peer_name string) (string, error)
+	GetFeed(peer_name string) ([]string, error)
+	Whoami() string
+	About(peer_name string) (string, error)
+	SetAbout(about About) error
+	Publish(data string) error
+	AddRessource(b64 string) (string, error)
+	GetRessource(id string) (string, error)
+	Resolve(name string) (string, error)
+}
+
 type Ledger struct {
 	Repo string
 
 	sh *shell.Shell // IPFS api
 }
 
-func NewLedger(repo_path string, ipfs_api string) Ledger {
+func NewLedger(repo_path string, ipfs_api string) *Ledger {
 	// Create some files if needed
 	checkAndMake(repo_path)
 	checkAndMake(repo_path + "/feed")
@@ -52,7 +66,7 @@ func NewLedger(repo_path string, ipfs_api string) Ledger {
 	checkAndMakeFile(repo_path+"/lastseq", []byte("0"))
 	checkAndMakeFile(repo_path+"/about.json", []byte("{}"))
 
-	return Ledger{Repo: repo_path, sh: shell.NewShell(ipfs_api)}
+	return &Ledger{Repo: repo_path, sh: shell.NewShell(ipfs_api)}
 }
 
 // Recursively add stuff in the repo and do an `ipfs name publish`


### PR DESCRIPTION
This way we can have 2 different implementations:
  * Actual Ledger, which communicates with IPFS
  * Mock implementation, which can be used for unit testing and don't depend on IPFS daemon running or network connection

With that I've replaced the Api testing for using the new Mock version

> Please check you are not duplicating an existing pull request...

#### Changes
*Document here your changes*

#### Verification
*Steps to verify the pull request works as intended*
 -  ...
 -  ...
